### PR TITLE
formatTimeItem does not work on single digits

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export function isNumber(value) {
 }
 
 export function formatTimeItem(value) {
-  return `${value || ''}00`.substr(0, 2);
+  return `00${value || ''}`.substr(2, -2);
 }
 
 export function validateTimeAndCursor(


### PR DESCRIPTION
This is with the formatTimeItem implementation above: 
```
ft = value =>  `00${value || ''}`.substr(-2, 2)
> ft(0)
'00'
> ft(1)
'01'
> ft(18)
'18'
> ft(60)
'60'
> ft(59)
'59'
> 
```

This is with the old one:

```
ft = value =>  `${value || ''}00`.substr(0, 2)
[Function: ft]
> ft(59)
'59'
> ft(1)
'10'
> ft(18)
'18'
> ft(8)
'80'
```


```