### PR TITLE
fix(typings): build and provide type definitions to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "main": "index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && cd ./demo && npm run build && cd -",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "declaration": true,
     "jsx": "react"
   },
   "include": [


### PR DESCRIPTION
This PR changes the `tsconfig` to build the type definitions, and configures package.json to refer correctly to the built types. 

Not sure why this wasn't already enabled.
