### PR TITLE
Accept React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17",
+    "react-dom": "^16.0.0 || ^17"
   },
   "devDependencies": {
     "@types/enzyme": "3.10.4",


### PR DESCRIPTION
Updates peer dependency to allow react and react-dom v17 in addition to v16