### PR TITLE
fix allow synthetic default import

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import React, {ChangeEvent, CSSProperties, ReactElement} from 'react';
+import * as React from 'react';
+import {ChangeEvent, CSSProperties, ReactElement} from 'react';
 
 const DEFAULT_COLON = ':';
 const DEFAULT_VALUE_SHORT = `00${DEFAULT_COLON}00`;


### PR DESCRIPTION
Hello!
Current version of the library forces all users to enable allowSyntheticDefaultImports option in tsconfig. Without this option TypeScript breaks on import React from 'react', you should use import * as React from 'react'.

It's better not to force users to have non-default options in tsconfig.